### PR TITLE
feat(backend): #40 Filtrage des minutes avec -m

### DIFF
--- a/src/main/java/org/vaadin/projet10/backend/commands/mastodonte/Options.java
+++ b/src/main/java/org/vaadin/projet10/backend/commands/mastodonte/Options.java
@@ -1,22 +1,27 @@
 package org.vaadin.projet10.backend.commands.mastodonte;
 
 public class Options {
-    private int days = -1;
+    private Integer days = null;
     private boolean verbose = false;
     private int minLikes = -1;
     private int minReplies = -1;
     private String error;
+    private Integer minutes = null;
 
     public boolean hasFilter() {
-        return days > 0;
+        return hasDays() || hasMinutes();
     }
 
-    public int getDays() {
-        return days;
+    public Integer getDays() {
+        return days != null ? days : 0;
     }
 
-    public void setDays(int d) {
+    public void setDays(Integer d) {
         this.days = d;
+    }
+
+    public boolean hasDays(){
+        return days != null;
     }
 
     public boolean isVerbose() {
@@ -60,5 +65,15 @@ public class Options {
     }
     public boolean hasReplyFilter() {
         return minReplies >= 0;
+    }
+    public Integer getMinutes(){
+        return minutes != null ? minutes : 0;
+    }
+    public void setMinutes(Integer minutes){
+        this.minutes = minutes;
+    }
+
+    public boolean hasMinutes(){
+        return minutes != null;
     }
 }

--- a/src/main/java/org/vaadin/projet10/backend/commands/mastodonte/OptionsParser.java
+++ b/src/main/java/org/vaadin/projet10/backend/commands/mastodonte/OptionsParser.java
@@ -16,6 +16,18 @@ public class OptionsParser {
                             opts.setError("Option -d invalide : nombre attendu.");
                         }
                     }
+                    else{
+                        opts.setError("Option -d attend une valeur (nombre de jours).");
+                    }
+                    break;
+                case "-m":
+                    if (i + 1 < args.length){
+                        try{
+                            opts.setMinutes(Integer.parseInt(args[++i]));
+                        } catch (NumberFormatException e){
+                            opts.setError("Option -m invalide : nombre attendu.");
+                        }
+                    }
                     break;
                 case "-l":  // min likes
                     if (i + 1 < args.length) {

--- a/src/main/java/org/vaadin/projet10/backend/commands/mastodonte/OutputFormatter.java
+++ b/src/main/java/org/vaadin/projet10/backend/commands/mastodonte/OutputFormatter.java
@@ -3,6 +3,7 @@ package org.vaadin.projet10.backend.commands.mastodonte;
 import org.vaadin.projet10.backend.model.MastodonPost;
 
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
 
 public class OutputFormatter {
@@ -10,10 +11,12 @@ public class OutputFormatter {
 
     public String format(List<MastodonPost> posts, Options opts, String tag, int limit) {
         if (posts.isEmpty()) {
-            return String.format("Aucun post pour #%s%s", tag, opts.hasFilter() ? " dans les " + opts.getDays() + " jours" : "");
+            return String.format("Aucun post pour #%s%s", tag, opts.hasFilter() ? " dans les " + formatMessageDateMinute(opts) : "");
         }
         StringBuilder sb = new StringBuilder();
-        sb.append(opts.hasFilter() ? String.format("Posts pour le hashtag %s (derniers %d jours):%n", tag, opts.getDays()) : String.format("Posts pour le hashtag %s (populaires):%n", tag));
+        sb.append(opts.hasFilter() 
+            ? String.format("Posts pour le hashtag %s (dans les %s):%n", tag, formatMessageDateMinute(opts)) 
+            : String.format("Posts pour le hashtag %s (populaires):%n", tag));
 
         for (int i = 0; i < posts.size() && i < limit; i++) {
             MastodonPost p = posts.get(i);
@@ -26,5 +29,40 @@ public class OutputFormatter {
             sb.append("\n");
         }
         return sb.toString();
+    }
+
+    private String formatMessageDateMinute(Options opts){
+        boolean hasD = opts.hasDays();
+        boolean hasM = opts.hasMinutes();
+
+        int d = opts.getDays();
+        int m = opts.getMinutes();
+
+        //N'affiche que les jours quand on utilise -d
+        if (hasD && !hasM){
+            return d + " jour" + (d > 1 ? "s" : "");
+        }
+        //N'affiche que les minutes quand on utilise -m
+        if (!hasD && hasM){
+            int heures = m / 60;
+            int minutes = m % 60;
+            List<String> parts = new ArrayList<>();
+            if (heures > 0) parts.add(heures + " heure" + (heures > 1 ? "s" : ""));
+            if (minutes > 0) parts.add(minutes + " minute" + (minutes > 1 ? "s" : ""));
+            return String.join(" et ", parts);
+        }
+
+        int totalMinutes = opts.getDays() * 1440 + opts.getMinutes();
+
+        int jours = totalMinutes / 1440;
+        int heures = (totalMinutes % 1440) / 60;
+        int minutes = totalMinutes % 60;
+
+        List<String> parts = new ArrayList<>();
+        if (jours > 0) parts.add(jours + " jour" + (jours > 1 ? "s" : ""));
+        if (heures > 0) parts.add(heures + " heure" + (heures > 1 ? "s" : ""));
+        if (minutes > 0) parts.add(minutes + " minute" + (minutes > 1 ? "s" : ""));
+        if (parts.isEmpty()) return "";
+        return String.join(" , ", parts);
     }
 }

--- a/src/main/java/org/vaadin/projet10/backend/commands/mastodonte/RecentProcessor.java
+++ b/src/main/java/org/vaadin/projet10/backend/commands/mastodonte/RecentProcessor.java
@@ -2,6 +2,7 @@ package org.vaadin.projet10.backend.commands.mastodonte;
 
 import org.vaadin.projet10.backend.model.MastodonPost;
 
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 //import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -10,7 +11,9 @@ import java.util.stream.Collectors;
 public class RecentProcessor implements Processor {
     @Override
     public List<MastodonPost> process(List<MastodonPost> posts, Options opts) {
-        ZonedDateTime threshold = ZonedDateTime.now().minusDays(opts.getDays());
+        ZonedDateTime threshold = ZonedDateTime.now(ZoneOffset.UTC)
+            .minusDays(opts.getDays())
+            .minusMinutes(opts.getMinutes());
         return posts.stream().filter(p -> p.getCreatedAt().isAfter(threshold)).sorted((a, b) -> b.getCreatedAt().compareTo(a.getCreatedAt())).collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
Filtre les minutes avec l'option -m.
Cette option peut être utiliser seul ou avec -d.
Si les minutes dépasse 59 minutes, les convertit en heures et minutes : 90 minutes devient 1 heure et 30 minute.